### PR TITLE
fixed top/par problems

### DIFF
--- a/tutorials/conformational_sampling/optimize.rst
+++ b/tutorials/conformational_sampling/optimize.rst
@@ -23,19 +23,22 @@ their location as follows:
 
 .. ipython:: python
 
+   tcl_cmd = '''package require readcharmmpar
+   package require readcharmmtop
+   global env
+   set outfile [open charmmdir.txt w]
+   puts $outfile $env(CHARMMPARDIR)
+   puts $outfile $env(CHARMMTOPDIR)
+   close $outfile
+   exit'''
    with open('where_is_charmmpar.tcl', 'w') as inp:
-       inp.write('''global env;
-   set outfile [open charmmdir.txt w];
-   puts $outfile "$env(CHARMMPARDIR)";
-   puts $outfile "$env(CHARMMTOPDIR)";
-   close $outfile;
-   exit;''')
+      inp.write(tcl_cmd)
 
 This can be run in vmd from ipython as below:
 
 .. ipython:: python
 
-   !vmd -e where_is_charmmpar.tcl
+   !vmd -dispdev text -e where_is_charmmpar.tcl
 
 We then read the output file to get the parameter directory:
 
@@ -58,7 +61,7 @@ Let's make a folder for writing optimization input and output files:
 
 .. ipython:: python
 
-    mkdir -p p38_optimize
+   mkdir -p p38_optimize
 
 We will write an NAMD configuration file for each conformation based
 on :file:`min.conf`:

--- a/tutorials/signdy_tutorial/overview.rst
+++ b/tutorials/signdy_tutorial/overview.rst
@@ -151,16 +151,16 @@ distributions for each of those modes. To arrange the plots like this, we use th
 .. ipython:: python
 
    @savefig signdy_dali_variance_mode1-5.png width=4in
-   figure();
+   plt.figure()
    gs = GridSpec(ncols=1, nrows=2, height_ratios=[1, 10], hspace=0.15)
 
-   subplot(gs[0]);
-   showVarianceBar(gnms[:, :5], fraction=True, highlights=highlights);
-   xlabel('');
+   subplot(gs[0])
+   showVarianceBar(gnms[:, :5], fraction=True, highlights=highlights)
+   xlabel('')
 
-   subplot(gs[1]);
-   showSignatureVariances(gnms[:, :5], fraction=True, bins=80, alpha=0.7);
-   xlabel('Fraction of inverse eigenvalue');
+   subplot(gs[1])
+   showSignatureVariances(gnms[:, :5], fraction=True, bins=80, alpha=0.7)
+   xlabel('Fraction of inverse eigenvalue')
 
 
 Spectral overlap and distance

--- a/where_is_charmmpar.tcl
+++ b/where_is_charmmpar.tcl
@@ -1,6 +1,0 @@
-global env;
-set outfile [open charmmdir.txt w];
-puts $outfile "$env(CHARMMPARDIR)";
-puts $outfile "$env(CHARMMTOPDIR)";
-close $outfile
-exit;


### PR DESCRIPTION
Without "package require readcharmmpar
package require readcharmmtop
"
$env(CHARMMPARDIR) and $env(CHARMMTOPDIR) cannot be used outside the VMD TKConsole. 