### PR TITLE
redid links for workshops

### DIFF
--- a/_template/prody.html
+++ b/_template/prody.html
@@ -95,7 +95,7 @@
                   Lectures, tutorials and other materials from out latest workshops are available 
                   <a href="http://prody.csb.pitt.edu/workshop">here</a>.
                   Our previous (2019) workshop materials can be reached from
-                  <a href="http://prody.csb.pitt.edu/workshop2019">this link</a>
+                  <a href="http://prody.csb.pitt.edu/workshop2019">this link</a>.
                 </small>
               </p>
             </div>

--- a/_template/prody.html
+++ b/_template/prody.html
@@ -93,9 +93,9 @@
                   <i>NAMD/VMD</i> development team as part of the activities of the 
                   <a href="https://www.mmbios.org/">MMBioS</a> Center. 
                   Lectures, tutorials and other materials from out latest workshops are available 
-                  <a href="http://prody.csb.pitt.edu/workshop">here</a>.
+                  <a href="http://prody.csb.pitt.edu/test_prody/_build/html/workshop">here</a>.
                   Our previous (2019) workshop materials can be reached from
-                  <a href="http://prody.csb.pitt.edu/workshop2019">this link</a>.
+                  <a href="http://prody.csb.pitt.edu/workshop">this link</a>.
                 </small>
               </p>
             </div>

--- a/_template/tutorials.html
+++ b/_template/tutorials.html
@@ -12,9 +12,9 @@
                   <a href="https://www.mmbios.org/">MMBioS</a> funded by 
                   <a href="http://www.nih.gov/" target="_blank">NIH</a> through the P41 GM103712 award.
                   Lectures, tutorials and other materials from the latest workshops are available 
-                  <a href="http://prody.csb.pitt.edu/workshop">here</a>.<br>
-                  Our previous (2019) workshop materials can be reached 
-                  from <a href="http://prody.csb.pitt.edu/workshop2019">this link</a>
+                  <a href="http://prody.csb.pitt.edu/test_prody/_build/html/workshop">here</a>.
+                  Our previous (2019) workshop materials can be reached from
+                  <a href="http://prody.csb.pitt.edu/workshop">this link</a>.
                 </small>
               </div>
               <ul class="thumbnails">


### PR DESCRIPTION
This way we access the new workshop on test_prody and the old one on the main prody website.