### PR TITLE
remove all refs to nmwiz chimera

### DIFF
--- a/_template/nmwiz.html
+++ b/_template/nmwiz.html
@@ -33,8 +33,7 @@
 
             <h4>Download</h4>
             <p><i>NMWiz</i> is distributed with <a href="http://www.ks.uiuc.edu/Development/Download/download.cgi?PackageName=VMD">VMD</a>
-            since v1.9.1. For updates that are not yet available in VMD latest release and for Chimera version, check out
-            <a href="{{ pathto('tutorials/nmwiz_tutorial/intro') }}">Getting NMWiz</a>. 
+            since v1.9.1. For more information, check out <a href="{{ pathto('tutorials/nmwiz_tutorial/intro') }}">the tutorial</a>. 
             </p>
             <p>
               <p>

--- a/tutorials/nmwiz_tutorial/intro.rst
+++ b/tutorials/nmwiz_tutorial/intro.rst
@@ -3,7 +3,7 @@
 Normal Mode Wizard
 ===============================================================================
 
-Normal Mode Wizard (NMWiz) is a VMD/Chimera plugin for depiction, animation, and
+Normal Mode Wizard (NMWiz) is a VMD plugin for depiction, animation, and
 comparative analysis of normal modes.  Normal modes may come from principal
 component of structural ensembles, essential dynamics analysis of simulation
 trajectories, or normal mode analysis of protein structures.  In addition,
@@ -13,7 +13,7 @@ NMWiz can be used to depict any vector that describes a molecular motion.
 Required Programs
 -------------------------------------------------------------------------------
 
-The latest versions of ProDy_ (1.4 or later) and VMD_ (1.9.2 or later) or `Chimera`__ (1.11 or later) are required.
+The latest versions of ProDy_ (1.4 or later) and VMD_ (1.9.2 or later) are required.
 
 Getting Started
 -------------------------------------------------------------------------------
@@ -21,5 +21,3 @@ Getting Started
 To follow this tutorial, you will need the following files:\
 
 .. literalinclude:: files.txt
-
-__ http://www.cgl.ucsf.edu/chimera/


### PR DESCRIPTION
NMWiz for Chimera doesn't really work very well (see https://github.com/prody/ProDy/issues/1319) so we are removing mention of it from the website. The tutorials for it are already absent. 