### PR TITLE
PRS tutorial fix

### DIFF
--- a/tutorials/prs_tutorial/analysis.rst
+++ b/tutorials/prs_tutorial/analysis.rst
@@ -83,7 +83,7 @@ We slice rows by default (*axis=0*) to obtain the effectiveness profile
                                          select='chain B and resnum 84')
 
     writePDB('3kg2_ca_B_84_effectiveness.pdb', ampar_ca, 
-             betas=B_84_effectiveness)
+             beta=B_84_effectiveness)
 
 
 and slice columns using *axis=1* to obtain the sensitivity profile
@@ -95,7 +95,7 @@ and slice columns using *axis=1* to obtain the sensitivity profile
                                        select='chain B and resnum 84')
 
     writePDB('3kg2_ca_B_84_sensitivity.pdb', ampar_ca, 
-             betas=B_84_sensitivity)
+             beta=B_84_sensitivity)
 
 We generated our Figure 7 using this approach together with the `spectrum` command from PyMOL.
 

--- a/tutorials/prs_tutorial/calculations.rst
+++ b/tutorials/prs_tutorial/calculations.rst
@@ -33,7 +33,7 @@ MD simulation.
 
     anm_ampar = ANM('AMPAR 3kg2')
     anm_ampar.buildHessian(ampar_ca)
-    anm_ampar.calcModes()
+    anm_ampar.calcModes('all')
 
 PRS can also be performed with any other model from which a covariance matrix 
 can be calculated including GNM and PCA. A PCA model can also be used with an 

--- a/tutorials/prs_tutorial/calculations.rst
+++ b/tutorials/prs_tutorial/calculations.rst
@@ -24,10 +24,8 @@ atoms, which we will use in downstream steps.
 
 
 Next, create an ANM instance and calculate modes from which the covariance
-matrix can be calculated. We could ask for all modes rather than the default subset
-of the first 20 global modes. We could alternatively apply the PRS to another
-model from which a covariance matrix could be derived such as PCA, GNM or an
-MD simulation.
+matrix can be calculated. We ask for all modes rather than the default subset
+of the first 20 global modes to reproduce the published data. 
 
 .. ipython:: python
 


### PR DESCRIPTION
These fixes are in response to https://github.com/prody/ProDy/issues/1349:

1. writePDB keyword argument was wrong so PRS profiles were not getting written to the b-factor field
2. All modes are needed to reproduce Dutta et al. 2015. Arguably this is the proper way to do PRS. 