### PR TITLE
added missing savefig

### DIFF
--- a/tutorials/ensemble_analysis/xray_calculations.rst
+++ b/tutorials/ensemble_analysis/xray_calculations.rst
@@ -146,6 +146,7 @@ missing atoms in the datasets:
 
    abs(pca_svd.getEigvals()[:20] - pca.getEigvals()).max()
    abs(calcOverlap(pca, pca_svd).diagonal()[:20]).min()
+   @savefig ensemble_analysis_xray_overlap_table_svd_1.png width=4in
    showOverlapTable(pca, pca_svd[:20])
 
 If we remove the most variable loop from the analysis, then these results 


### PR DESCRIPTION
There's no figure showing up but instead the following:
```
In [20]: showOverlapTable(pca, pca_svd[:20])
Out[20]: 
(<matplotlib.image.AxesImage at 0x7f843e4e1c90>,
 [],
 <matplotlib.colorbar.Colorbar at 0x7f843fe901d0>)
```