### PR TITLE
Tutorial fixes

### DIFF
--- a/tutorials/comd_tutorial/analyze.rst
+++ b/tutorials/comd_tutorial/analyze.rst
@@ -77,15 +77,15 @@ filtered to contain only C-alpha atoms as set in the previous step:
 	writeDCD('initial_filtered.dcd', dcd1)
 	writeDCD('final_filtered.dcd', dcd2)
 
-One way to combined trajectories into the same object is the :meth:`addFile` method 
-of :class:`Trajectory` objects.
+One way to combined trajectories into the same object is the :meth:`.Trajectory.addFile` method 
+of :class:`.Trajectory` objects.
 
 .. ipython:: python
 
 	traj = Trajectory('initial_filtered.dcd')
 	traj.addFile('final_filtered.dcd')
 
-Alternatively we can create an :class:`Ensemble` using :func:`parseDCD`,
+Alternatively we can create an :class:`.Ensemble` using :func:`.parseDCD`,
 which gives us the flexibility to do things like reversing the final 
 trajectory to create something we can view in VMD_ rather than having
 the trajectories both run towards the shared intermediate. 

--- a/tutorials/essa_tutorial/essa.rst
+++ b/tutorials/essa_tutorial/essa.rst
@@ -52,7 +52,7 @@ ESSA can be informed about them when setting the system as follows:
 
    essa.setSystem(ag, lig='A 300 A 301')
 
-Scanning can be done using :func:`.scanResidues`. Here one can specify the number 
+Scanning can be done using :meth:`.ESSA.scanResidues`. Here one can specify the number 
 of softest modes, the type of ENM (GNM or ANM), and the cutoff, which by default 
 are ``n_modes=10``, ``enm='gnm'``, ``cutoff=None``, respectively. If ``cutoff`` 
 is not specified, its value is adopted from the default value of the specified ENM. 
@@ -62,7 +62,7 @@ During the scanning, the progress will also be displayed.
 
    essa.scanResidues()
 
-The generated ESSA profile can be shown by :func:`.showESSAProfile`. On this profile, 
+The generated ESSA profile can be shown by :meth:`.ESSA.showESSAProfile`. On this profile, 
 the residues interacting with the previously specified ligand(s) are automatically 
 highlighted. The blue dashed baseline shows the q-th quantile of the profile, which is by 
 default ``q=0.75``, representing the top quartile. Other residues of interest 

--- a/tutorials/essa_tutorial/essa.rst
+++ b/tutorials/essa_tutorial/essa.rst
@@ -52,7 +52,7 @@ ESSA can be informed about them when setting the system as follows:
 
    essa.setSystem(ag, lig='A 300 A 301')
 
-Scanning can be done using :func:`.scanResidue`. Here one can specify the number 
+Scanning can be done using :func:`.scanResidues`. Here one can specify the number 
 of softest modes, the type of ENM (GNM or ANM), and the cutoff, which by default 
 are ``n_modes=10``, ``enm='gnm'``, ``cutoff=None``, respectively. If ``cutoff`` 
 is not specified, its value is adopted from the default value of the specified ENM. 


### PR DESCRIPTION
- typo fix spotted on ESSA tutorial
- rst formatting fixes to make links work on ESSA and CoMD tutorials