### PR TITLE
downweight sudo as in INSTALL.rst

### DIFF
--- a/_template/downloads.html
+++ b/_template/downloads.html
@@ -60,10 +60,10 @@
                     $ tar -xzf ProDy-{{ version }}.tar.gz
                     $ cd ProDy-{{ version }}
                     $ python setup.py build
-                    $ sudo python setup.py install
+                    $ python setup.py install
                   </pre>
 
-                  If you don’t have root access, see alternate installation schemes in <a href="https://docs.python.org/2/installing/">Installing Python Modules</a>.
+                  If you need root access for installation, try ``sudo python setup.py install``. If you don’t have root access, see alternate installation schemes in <a href="https://docs.python.org/2/installing/">Installing Python Modules</a>.
 
                 </div>
                 <div class="tab-pane" id="windows">


### PR DESCRIPTION
People really shouldn't have to rely on sudo by default, especially if they have conda as recommended. 