### PR TITLE
add seed to evol tutorial

### DIFF
--- a/tutorials/evol_tutorial/comparison.rst
+++ b/tutorials/evol_tutorial/comparison.rst
@@ -21,14 +21,14 @@ First, we retrieve MSA for protein for protein family :pfam:`PF00074`:
 .. ipython::
    :verbatim:
 
-   In [1]: fetchPfamMSA('PF00074')
-   Out[1]: 'PF00074_full.sth'
+   In [1]: fetchPfamMSA('PF00074', alignment='seed')
+   Out[1]: 'PF00074_seed.sth'
 
 We parse the MSA file:
 
 .. ipython:: python
 
-   msa = parseMSA('PF00074_full.sth')
+   msa = parseMSA('PF00074_seed.sth')
 
 Then, we refine it using :func:`.refineMSA` based on the sequence of
 :uniprot:`RNAS1_BOVIN`:

--- a/tutorials/evol_tutorial/msaanalysis.rst
+++ b/tutorials/evol_tutorial/msaanalysis.rst
@@ -32,14 +32,14 @@ We can do this by specifying the PDB ID of a protein in this family.
 .. ipython::
    :verbatim:
 
-   In [2]: fetchPfamMSA('PF00074')
-   Out[2]: 'PF00074_full.sth'
+   In [2]: fetchPfamMSA('PF00074', alignment='seed')
+   Out[2]: 'PF00074_seed.sth'
 
 Let's parse the downloaded file:
 
 .. ipython:: python
 
-   msa = parseMSA('PF00074_full.sth')
+   msa = parseMSA('PF00074_seed.sth')
 
 
 Refine MSA

--- a/tutorials/evol_tutorial/msafiles.rst
+++ b/tutorials/evol_tutorial/msafiles.rst
@@ -49,17 +49,17 @@ compressed files, but reading uncompressed files is much faster.
 .. ipython::
    :verbatim:
 
-   In [1]: fetchPfamMSA('PF02171', compressed=True)
-   Out[1]: 'PF02171_full.sth.gz'
+   In [1]: fetchPfamMSA('PF02171', compressed=True, alignment='seed')
+   Out[1]: 'PF02171_seed.sth.gz'
 
-   In [2]: parseMSA('PF02171_full.sth.gz')
-   Out[2]: <MSA: PF02171_full (2067 sequences, 1392 residues)>
+   In [2]: parseMSA('PF02171_seed.sth.gz')
+   Out[2]: <MSA: PF02171_seed (2067 sequences, 1392 residues)>
 
-   In [3]: fetchPfamMSA('PF02171', format='fasta')
-   Out[3]: 'PF02171_full.fasta.gz'
+   In [3]: fetchPfamMSA('PF02171', format='fasta', alignment='seed')
+   Out[3]: 'PF02171_seed.fasta.gz'
 
-   In [3]: parseMSA('PF02171_full.fasta.gz')
-   Out[3]: <MSA: PF02171_full (2067 sequences, 1392 residues)>
+   In [3]: parseMSA('PF02171_seed.fasta.gz')
+   Out[3]: <MSA: PF02171_seed (2067 sequences, 1392 residues)>
 
 
 Iterating over a file will yield sequence id, sequence, residue start and


### PR DESCRIPTION
Updated pfam usually doesn't provide full alignment as easily and prody usually can't get them, so we demonstrate using seed instead. Probably should update ProDy default argument too